### PR TITLE
Length before data

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,6 +25,13 @@ cc_library(
     strip_include_prefix = "include",
 )
 
+cc_library(
+    name = "test_headers",
+    hdrs = glob(["test/**/*.h"]),
+    copts = DEFAULT_COMPILER_OPTIONS,
+    strip_include_prefix = "test/unit/osi_layers",
+)
+
 [
     cc_test(
         name = "unit/" + unit_name,
@@ -33,7 +40,7 @@ cc_library(
         ],
         copts = DEFAULT_COMPILER_OPTIONS,
         tags = ["unit"],
-        deps = DEFAULT_TEST_DEPS,
+        deps = DEFAULT_TEST_DEPS + [":test_headers"],
     )
     for unit_name in [
         file_name.replace("test/unit/", "").replace(".cpp", "")

--- a/include/osi_layers/datalink.h
+++ b/include/osi_layers/datalink.h
@@ -18,7 +18,7 @@ class UartHandshake
 public:
     UartHandshake(TVoidUint8 on_transmit, TUint8Void on_receive) : io_{on_transmit, on_receive} {}
     CommunicationStatus TransmitWithAcknowledge(const Payload &payload, uint8_t retransmit_count = kMaxRetransmitCount) const;
-    Payload ReceiveWithAcknowledge(uint8_t expected_count = 1 + kCRCSize) const;
+    Payload ReceiveWithAcknowledge() const;
 
 private:
     T io_;

--- a/include/osi_layers/physical.h
+++ b/include/osi_layers/physical.h
@@ -13,7 +13,7 @@ public:
   Transceiver(TVoidUint8 on_transmit, TUint8Void on_receive) : on_transmit_byte_{on_transmit}, on_receive_byte_{on_receive} {}
 
   void Transmit(const Payload &payload) const;
-  Payload Receive(uint8_t expected_count = 1 + kCRCSize) const;
+  Payload Receive() const;
 
 private:
   TVoidUint8 on_transmit_byte_;

--- a/include/payload.h
+++ b/include/payload.h
@@ -5,8 +5,8 @@
 
 struct Payload
 {
-    uint8_t data[kPayloadMaxSize];
     uint8_t size;
+    uint8_t data[kPayloadMaxSize];
 
     Payload()
     {

--- a/include/payload.h
+++ b/include/payload.h
@@ -5,8 +5,8 @@
 
 struct Payload
 {
-    uint8_t size;
-    uint8_t data[kPayloadMaxSize];
+    uint8_t size{0};
+    uint8_t data[kPayloadMaxSize]{};
 
     Payload()
     {
@@ -39,7 +39,8 @@ struct Payload
 
     void Reset()
     {
-        for (uint8_t i = 0; i < size; ++i)
+
+        for (uint8_t i = 0; i < kPayloadMaxSize; ++i)
         {
             data[i] = 0;
         }
@@ -53,6 +54,7 @@ struct Payload
         {
             for (uint8_t i = 0; i < size; ++i)
             {
+
                 if (data[i] != rhs.data[i])
                 {
 

--- a/src/osi_layers/datalink.cpp
+++ b/src/osi_layers/datalink.cpp
@@ -26,24 +26,21 @@ CommunicationStatus UartHandshake<>::TransmitWithAcknowledge(const Payload &payl
 }
 
 template <>
-Payload UartHandshake<>::ReceiveWithAcknowledge(uint8_t expected_count) const
+Payload UartHandshake<>::ReceiveWithAcknowledge() const
 {
     Payload received;
     CommunicationStatus status{CommunicationStatus::Unknown};
-    if (expected_count < kPayloadMaxSize)
+
+    for (uint8_t i = 0; i < kMaxRetransmitCount && status != CommunicationStatus::Acknowledge; ++i)
     {
-        for (uint8_t i = 0; i < kMaxRetransmitCount && status != CommunicationStatus::Acknowledge; ++i)
-        {
-            received = io_.Receive(expected_count);
-            log_dump_payload(received, " Datalink :: ReceiveWithAcknowledge :: received");
+        received = io_.Receive();
+        log_dump_payload(received, " Datalink :: ReceiveWithAcknowledge :: received");
 
-            status = crc_match(received) ? CommunicationStatus::Acknowledge : CommunicationStatus::NegativeAcknowledge;
+        status = crc_match(received) ? CommunicationStatus::Acknowledge : CommunicationStatus::NegativeAcknowledge;
 
-            uint8_t data_response_[]{static_cast<uint8_t>(status)};
-            io_.Transmit(append_crc_to_payload(Payload{data_response_, 1}));
-        }
-
-        return crc_match(received) ? received : Payload{};
+        uint8_t data_response_[]{static_cast<uint8_t>(status)};
+        io_.Transmit(append_crc_to_payload(Payload{data_response_, 1}));
     }
-    return {};
+
+    return crc_match(received) ? received : Payload{};
 }

--- a/src/osi_layers/datalink.cpp
+++ b/src/osi_layers/datalink.cpp
@@ -16,10 +16,14 @@ CommunicationStatus UartHandshake<>::TransmitWithAcknowledge(const Payload &payl
 
         log_dump_payload(response, "Datalink :: (response)");
 
-        if (response.size)
+        if (response.size && crc_match(response))
         {
             result = static_cast<CommunicationStatus>(response.data[0]);
             log("Received CommunicationStatus response: " + std::to_string(response.data[0]));
+        }
+        else
+        {
+            log("CRC mismatch!");
         }
     }
     return result;

--- a/src/osi_layers/physical.cpp
+++ b/src/osi_layers/physical.cpp
@@ -6,20 +6,26 @@
 void Transceiver::Transmit(const Payload &payload) const
 {
     log_dump_payload(payload, "Physical :: Transmit");
+    on_transmit_byte_(payload.size);
     for (uint8_t i = 0; i < payload.size; ++i)
     {
         on_transmit_byte_(payload.data[i]);
     }
 }
 
-Payload Transceiver::Receive(const uint8_t expected_count) const
+Payload Transceiver::Receive() const
 {
     auto payload = Payload{};
 
-    for (uint8_t i = 0; i < expected_count; ++i)
+    auto expected_count = on_receive_byte_();
+    if (expected_count < kPayloadMaxSize)
     {
-        payload.data[payload.size++] = on_receive_byte_();
+        for (uint8_t i = 0; i < expected_count; ++i)
+        {
+            payload.data[payload.size++] = on_receive_byte_();
+        }
+        log_dump_payload(payload, "Physical :: Receive");
+        return payload;
     }
-    log_dump_payload(payload, "Physical :: Receive");
-    return payload;
+    return {};
 }

--- a/src/osi_layers/physical.cpp
+++ b/src/osi_layers/physical.cpp
@@ -6,6 +6,7 @@
 void Transceiver::Transmit(const Payload &payload) const
 {
     log_dump_payload(payload, "Physical :: Transmit");
+
     on_transmit_byte_(payload.size);
     for (uint8_t i = 0; i < payload.size; ++i)
     {
@@ -18,6 +19,7 @@ Payload Transceiver::Receive() const
     auto payload = Payload{};
 
     auto expected_count = on_receive_byte_();
+
     if (expected_count < kPayloadMaxSize)
     {
         for (uint8_t i = 0; i < expected_count; ++i)

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -6,6 +6,7 @@ void log_dump_payload(const Payload &payload, const std::string header)
 {
 
     std::cout << "---------" << header << "---------" << std::endl;
+    std::cout << "[" << std::dec << static_cast<int>(payload.size) << "] " << std::hex;
     for (uint8_t i = 0; i < payload.size; ++i)
     {
         std::cout << std::dec << static_cast<int>(payload.data[i]) << " ";

--- a/test/unit/osi_layers/test_datalink_rx_ack.cpp
+++ b/test/unit/osi_layers/test_datalink_rx_ack.cpp
@@ -24,18 +24,7 @@ public:
     static uint8_t generic_receive_byte()
     {
         static uint8_t call_count{0};
-
-        std::map<uint8_t, uint8_t> lookup_map{
-            {0, payloadified_data_.size},
-            {1, payloadified_data_.data[0]},
-            {2, payloadified_data_.data[1]},
-            {3, payloadified_data_.data[2]},
-            {4, payloadified_data_.data[3]},
-            {5, payloadified_data_.data[4]},
-            {6, payloadified_data_.data[5]},
-        };
-
-        return lookup_map[call_count++];
+        return lookup_map_[call_count++];
     }
 
 protected:
@@ -49,8 +38,18 @@ protected:
         payloadified_negative_acknowledge_ = append_crc_to_payload(payloadified_negative_acknowledge_);
         payloadified_acknowledge_ = append_crc_to_payload(payloadified_acknowledge_);
 
-        payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
+        payloadified_data_ = append_crc_to_payload(Payload{data_.c_str(), static_cast<uint8_t>(data_.length())});
         received_.size = 0;
+
+        lookup_map_ = {
+            {0, payloadified_data_.size},
+            {1, payloadified_data_.data[0]},
+            {2, payloadified_data_.data[1]},
+            {3, payloadified_data_.data[2]},
+            {4, payloadified_data_.data[3]},
+            {5, payloadified_data_.data[4]},
+            {6, payloadified_data_.data[5]},
+        };
     }
     virtual void TearDown() override {}
 
@@ -61,6 +60,7 @@ protected:
     static Payload payloadified_negative_acknowledge_;
     static Payload payloadified_acknowledge_;
     static Payload payloadified_data_;
+    static std::map<uint8_t, uint8_t> lookup_map_;
 };
 
 Payload Fixture::received_{};
@@ -69,10 +69,10 @@ std::string Fixture::data_{"abcd"};
 Payload Fixture::payloadified_negative_acknowledge_;
 Payload Fixture::payloadified_acknowledge_;
 Payload Fixture::payloadified_data_;
+std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, ReceiveWithAcknowledgeWorks_WhenTypical)
 {
-    payloadified_data_ = append_crc_to_payload(payloadified_data_);
     auto expected = Payload(data_.c_str(), static_cast<uint8_t>(data_.length()));
     expected = append_crc_to_payload(expected);
 

--- a/test/unit/osi_layers/test_datalink_rx_ack.cpp
+++ b/test/unit/osi_layers/test_datalink_rx_ack.cpp
@@ -9,11 +9,9 @@
 #include "osi_layers/datalink.h"
 
 #include "utilities.h"
+#include "test_unit_base.h"
 
-constexpr uint8_t data_negative_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::NegativeAcknowledge)};
-constexpr uint8_t data_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::Acknowledge)};
-
-class Fixture : public ::testing::Test
+class Fixture : public UnitBase
 {
 public:
     static void generic_transmit_byte(const uint8_t payload)
@@ -30,46 +28,20 @@ public:
 protected:
     virtual void SetUp() override
     {
-        received_.Reset();
-
-        payloadified_negative_acknowledge_ = Payload{data_negative_acknowledge_, 1};
-        payloadified_acknowledge_ = Payload{data_acknowledge_, 1};
-
-        payloadified_negative_acknowledge_ = append_crc_to_payload(payloadified_negative_acknowledge_);
-        payloadified_acknowledge_ = append_crc_to_payload(payloadified_acknowledge_);
-
-        payloadified_data_ = append_crc_to_payload(Payload{data_.c_str(), static_cast<uint8_t>(data_.length())});
-        received_.size = 0;
+        UnitBase::SetUp();
 
         lookup_map_ = {
-            {0, payloadified_data_.size},
-            {1, payloadified_data_.data[0]},
-            {2, payloadified_data_.data[1]},
-            {3, payloadified_data_.data[2]},
-            {4, payloadified_data_.data[3]},
-            {5, payloadified_data_.data[4]},
-            {6, payloadified_data_.data[5]},
+            {0, payloadified_data_with_crc_.size},
+            {1, payloadified_data_with_crc_.data[0]},
+            {2, payloadified_data_with_crc_.data[1]},
+            {3, payloadified_data_with_crc_.data[2]},
+            {4, payloadified_data_with_crc_.data[3]},
+            {5, payloadified_data_with_crc_.data[4]},
+            {6, payloadified_data_with_crc_.data[5]},
         };
     }
-    virtual void TearDown() override {}
-
-    static Payload received_;
     UartHandshake<> sut_{generic_transmit_byte, generic_receive_byte};
-
-    static std::string data_;
-    static Payload payloadified_negative_acknowledge_;
-    static Payload payloadified_acknowledge_;
-    static Payload payloadified_data_;
-    static std::map<uint8_t, uint8_t> lookup_map_;
 };
-
-Payload Fixture::received_{};
-
-std::string Fixture::data_{"abcd"};
-Payload Fixture::payloadified_negative_acknowledge_;
-Payload Fixture::payloadified_acknowledge_;
-Payload Fixture::payloadified_data_;
-std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, ReceiveWithAcknowledgeWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_datalink_rx_ack.cpp
+++ b/test/unit/osi_layers/test_datalink_rx_ack.cpp
@@ -23,7 +23,19 @@ public:
 
     static uint8_t generic_receive_byte()
     {
-        return payloadified_data_.data[received_.size++];
+        static uint8_t call_count{0};
+
+        std::map<uint8_t, uint8_t> lookup_map{
+            {0, payloadified_data_.size},
+            {1, payloadified_data_.data[0]},
+            {2, payloadified_data_.data[1]},
+            {3, payloadified_data_.data[2]},
+            {4, payloadified_data_.data[3]},
+            {5, payloadified_data_.data[4]},
+            {6, payloadified_data_.data[5]},
+        };
+
+        return lookup_map[call_count++];
     }
 
 protected:

--- a/test/unit/osi_layers/test_datalink_rx_ack.cpp
+++ b/test/unit/osi_layers/test_datalink_rx_ack.cpp
@@ -64,7 +64,7 @@ TEST_F(Fixture, ReceiveWithAcknowledgeWorks_WhenTypical)
     auto expected = Payload(data_.c_str(), static_cast<uint8_t>(data_.length()));
     expected = append_crc_to_payload(expected);
 
-    auto actual = sut_.ReceiveWithAcknowledge(expected.size);
+    auto actual = sut_.ReceiveWithAcknowledge();
 
     ASSERT_EQ(actual, expected);
 }

--- a/test/unit/osi_layers/test_datalink_rx_nack.cpp
+++ b/test/unit/osi_layers/test_datalink_rx_nack.cpp
@@ -9,11 +9,9 @@
 #include "osi_layers/datalink.h"
 
 #include "utilities.h"
+#include "test_unit_base.h"
 
-constexpr uint8_t data_negative_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::NegativeAcknowledge)};
-constexpr uint8_t data_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::Acknowledge)};
-
-class Fixture : public ::testing::Test
+class Fixture : public UnitBase
 {
 public:
     static void generic_transmit_byte(const uint8_t payload)
@@ -30,60 +28,28 @@ public:
 protected:
     virtual void SetUp() override
     {
-        transmitted_.Reset();
-        received_.Reset();
-
-        payloadified_negative_acknowledge_ = Payload{data_negative_acknowledge_, 1};
-        payloadified_acknowledge_ = Payload{data_acknowledge_, 1};
-
-        payloadified_negative_acknowledge_ = append_crc_to_payload(payloadified_negative_acknowledge_);
-        payloadified_acknowledge_ = append_crc_to_payload(payloadified_acknowledge_);
-
-        payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
-        payloadified_data_ = append_crc_to_payload(payloadified_data_);
-
-        received_.size = 0;
+        UnitBase::SetUp();
 
         lookup_map_ = {
-            {0, payloadified_data_.size},
-            {1, payloadified_data_.data[0]},
-            {2, payloadified_data_.data[1] + 1},
-            {3, payloadified_data_.data[2]},
-            {4, payloadified_data_.data[3]},
-            {5, payloadified_data_.data[4]},
-            {6, payloadified_data_.data[5]},
+            {0, payloadified_data_with_crc_.size},
+            {1, payloadified_data_with_crc_.data[0]},
+            {2, payloadified_data_with_crc_.data[1] + 1},
+            {3, payloadified_data_with_crc_.data[2]},
+            {4, payloadified_data_with_crc_.data[3]},
+            {5, payloadified_data_with_crc_.data[4]},
+            {6, payloadified_data_with_crc_.data[5]},
 
-            {7, payloadified_data_.size},
-            {8, payloadified_data_.data[0]},
-            {9, payloadified_data_.data[1]},
-            {10, payloadified_data_.data[2]},
-            {11, payloadified_data_.data[3]},
-            {12, payloadified_data_.data[4]},
-            {13, payloadified_data_.data[5]},
+            {7, payloadified_data_with_crc_.size},
+            {8, payloadified_data_with_crc_.data[0]},
+            {9, payloadified_data_with_crc_.data[1]},
+            {10, payloadified_data_with_crc_.data[2]},
+            {11, payloadified_data_with_crc_.data[3]},
+            {12, payloadified_data_with_crc_.data[4]},
+            {13, payloadified_data_with_crc_.data[5]},
         };
     }
-    virtual void TearDown() override {}
-
-    static Payload received_;
     UartHandshake<> sut_{generic_transmit_byte, generic_receive_byte};
-    static std::string data_;
-    static Payload payloadified_negative_acknowledge_;
-    static Payload payloadified_acknowledge_;
-    static Payload payloadified_data_;
-    static Payload transmitted_;
-
-    static std::map<uint8_t, uint8_t> lookup_map_;
 };
-
-Payload Fixture::received_{};
-
-std::string Fixture::data_{"abcd"};
-Payload Fixture::payloadified_negative_acknowledge_;
-Payload Fixture::payloadified_acknowledge_;
-Payload Fixture::payloadified_data_;
-
-Payload Fixture::transmitted_{};
-std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, ReceiveWithNegativeAcknowledgeTransmissionWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_datalink_rx_nack.cpp
+++ b/test/unit/osi_layers/test_datalink_rx_nack.cpp
@@ -85,7 +85,7 @@ TEST_F(Fixture, ReceiveWithNegativeAcknowledgeWorks_WhenTypical)
     auto expected = Payload(data_.c_str(), static_cast<uint8_t>(data_.length()));
     expected = append_crc_to_payload(expected);
 
-    auto actual = sut_.ReceiveWithAcknowledge(expected.size);
+    auto actual = sut_.ReceiveWithAcknowledge();
 
     ASSERT_EQ(actual, expected);
 }
@@ -101,7 +101,7 @@ TEST_F(Fixture, ReceiveWithNegativeAcknowledgeTransmissionWorks_WhenTypical)
 
     auto expected = Payload{nack_then_ack_with_crc, 6};
 
-    sut_.ReceiveWithAcknowledge(data_.length() + kCRCSize);
+    sut_.ReceiveWithAcknowledge();
     auto actual = transmitted_;
 
     log_dump_payload(actual, "actual");

--- a/test/unit/osi_layers/test_datalink_rx_nack.cpp
+++ b/test/unit/osi_layers/test_datalink_rx_nack.cpp
@@ -23,28 +23,8 @@ public:
 
     static uint8_t generic_receive_byte()
     {
-
         static uint8_t call_count{0};
-
-        std::map<uint8_t, uint8_t> lookup_map{
-            {0, payloadified_data_.size},
-            {1, payloadified_data_.data[0]},
-            {2, payloadified_data_.data[1] + 1},
-            {3, payloadified_data_.data[2]},
-            {4, payloadified_data_.data[3]},
-            {5, payloadified_data_.data[4]},
-            {6, payloadified_data_.data[5]},
-
-            {7, payloadified_data_.size},
-            {8, payloadified_data_.data[0]},
-            {9, payloadified_data_.data[1]},
-            {10, payloadified_data_.data[2]},
-            {11, payloadified_data_.data[3]},
-            {12, payloadified_data_.data[4]},
-            {13, payloadified_data_.data[5]},
-        };
-
-        return lookup_map[call_count++];
+        return lookup_map_[call_count++];
     }
 
 protected:
@@ -63,7 +43,24 @@ protected:
         payloadified_data_ = append_crc_to_payload(payloadified_data_);
 
         received_.size = 0;
-        call_count_ = 0;
+
+        lookup_map_ = {
+            {0, payloadified_data_.size},
+            {1, payloadified_data_.data[0]},
+            {2, payloadified_data_.data[1] + 1},
+            {3, payloadified_data_.data[2]},
+            {4, payloadified_data_.data[3]},
+            {5, payloadified_data_.data[4]},
+            {6, payloadified_data_.data[5]},
+
+            {7, payloadified_data_.size},
+            {8, payloadified_data_.data[0]},
+            {9, payloadified_data_.data[1]},
+            {10, payloadified_data_.data[2]},
+            {11, payloadified_data_.data[3]},
+            {12, payloadified_data_.data[4]},
+            {13, payloadified_data_.data[5]},
+        };
     }
     virtual void TearDown() override {}
 
@@ -74,7 +71,8 @@ protected:
     static Payload payloadified_acknowledge_;
     static Payload payloadified_data_;
     static Payload transmitted_;
-    static uint8_t call_count_;
+
+    static std::map<uint8_t, uint8_t> lookup_map_;
 };
 
 Payload Fixture::received_{};
@@ -85,7 +83,7 @@ Payload Fixture::payloadified_acknowledge_;
 Payload Fixture::payloadified_data_;
 
 Payload Fixture::transmitted_{};
-uint8_t Fixture::call_count_;
+std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, ReceiveWithNegativeAcknowledgeTransmissionWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_datalink_tx_ack.cpp
+++ b/test/unit/osi_layers/test_datalink_tx_ack.cpp
@@ -24,17 +24,21 @@ public:
     static uint8_t generic_receive_byte()
     {
         static uint8_t call_count = 0;
+        constexpr uint8_t payload_size_byte_count{1};
 
-        if (++call_count <= 1 + kCRCSize)
-        {
-            return payloadified_negative_acknowledge_.data[received_.size++];
-        }
-        else if (call_count == 1 + kCRCSize + 1)
-        {
-            received_.size = 0;
-        }
+        std::map<uint8_t, uint8_t> lookup_map{
+            {0, payload_size_byte_count + kCRCSize},
+            {1, payloadified_negative_acknowledge_.data[0]},
+            {2, payloadified_negative_acknowledge_.data[1]},
+            {3, payloadified_negative_acknowledge_.data[2]},
 
-        return payloadified_acknowledge_.data[received_.size++];
+            {4, payload_size_byte_count + kCRCSize},
+            {5, payloadified_acknowledge_.data[0]},
+            {6, payloadified_acknowledge_.data[1]},
+            {7, payloadified_acknowledge_.data[2]},
+        };
+
+        return lookup_map[call_count++];
     }
 
 protected:

--- a/test/unit/osi_layers/test_datalink_tx_ack.cpp
+++ b/test/unit/osi_layers/test_datalink_tx_ack.cpp
@@ -10,6 +10,7 @@
 
 #include "utilities.h"
 
+constexpr uint8_t payload_size_byte_count{1};
 constexpr uint8_t data_negative_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::NegativeAcknowledge)};
 constexpr uint8_t data_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::Acknowledge)};
 
@@ -24,21 +25,7 @@ public:
     static uint8_t generic_receive_byte()
     {
         static uint8_t call_count = 0;
-        constexpr uint8_t payload_size_byte_count{1};
-
-        std::map<uint8_t, uint8_t> lookup_map{
-            {0, payload_size_byte_count + kCRCSize},
-            {1, payloadified_negative_acknowledge_.data[0]},
-            {2, payloadified_negative_acknowledge_.data[1]},
-            {3, payloadified_negative_acknowledge_.data[2]},
-
-            {4, payload_size_byte_count + kCRCSize},
-            {5, payloadified_acknowledge_.data[0]},
-            {6, payloadified_acknowledge_.data[1]},
-            {7, payloadified_acknowledge_.data[2]},
-        };
-
-        return lookup_map[call_count++];
+        return lookup_map_[call_count++];
     }
 
 protected:
@@ -54,6 +41,18 @@ protected:
 
         payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
         received_.size = 0;
+
+        lookup_map_ = {
+            {0, payload_size_byte_count + kCRCSize},
+            {1, payloadified_negative_acknowledge_.data[0]},
+            {2, payloadified_negative_acknowledge_.data[1]},
+            {3, payloadified_negative_acknowledge_.data[2]},
+
+            {4, payload_size_byte_count + kCRCSize},
+            {5, payloadified_acknowledge_.data[0]},
+            {6, payloadified_acknowledge_.data[1]},
+            {7, payloadified_acknowledge_.data[2]},
+        };
     }
     virtual void TearDown() override {}
 
@@ -64,6 +63,7 @@ protected:
     static Payload payloadified_negative_acknowledge_;
     static Payload payloadified_acknowledge_;
     static Payload payloadified_data_;
+    static std::map<uint8_t, uint8_t> lookup_map_;
 };
 
 Payload Fixture::received_{};
@@ -72,6 +72,8 @@ std::string Fixture::data_{"abcd"};
 Payload Fixture::payloadified_negative_acknowledge_;
 Payload Fixture::payloadified_acknowledge_;
 Payload Fixture::payloadified_data_;
+
+std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, TransmitWithAcknowledgeWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_datalink_tx_ack.cpp
+++ b/test/unit/osi_layers/test_datalink_tx_ack.cpp
@@ -4,44 +4,17 @@
 #include <memory>
 #include <string>
 
-#include "osi_layers/physical.h"
-#include "crc.h"
 #include "osi_layers/datalink.h"
 
 #include "utilities.h"
+#include "test_unit_base.h"
 
-constexpr uint8_t payload_size_byte_count{1};
-constexpr uint8_t data_negative_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::NegativeAcknowledge)};
-constexpr uint8_t data_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::Acknowledge)};
-
-class Fixture : public ::testing::Test
+class Fixture : public UnitBase
 {
 public:
-    static void generic_transmit_byte(const uint8_t payload)
-    {
-        static_cast<void>(payload);
-    }
-
-    static uint8_t generic_receive_byte()
-    {
-        static uint8_t call_count = 0;
-        return lookup_map_[call_count++];
-    }
-
-protected:
     virtual void SetUp() override
     {
-        received_.Reset();
-
-        payloadified_negative_acknowledge_ = Payload{data_negative_acknowledge_, 1};
-        payloadified_acknowledge_ = Payload{data_acknowledge_, 1};
-
-        payloadified_negative_acknowledge_ = append_crc_to_payload(payloadified_negative_acknowledge_);
-        payloadified_acknowledge_ = append_crc_to_payload(payloadified_acknowledge_);
-
-        payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
-        received_.size = 0;
-
+        UnitBase::SetUp();
         lookup_map_ = {
             {0, payload_size_byte_count + kCRCSize},
             {1, payloadified_negative_acknowledge_.data[0]},
@@ -54,26 +27,20 @@ protected:
             {7, payloadified_acknowledge_.data[2]},
         };
     }
-    virtual void TearDown() override {}
+    static void generic_transmit_byte(const uint8_t payload)
+    {
+        static_cast<void>(payload);
+    }
 
-    static Payload received_;
+    static uint8_t generic_receive_byte()
+    {
+        static uint8_t call_count = 0;
+        return lookup_map_[call_count++];
+    }
+
+protected:
     UartHandshake<> sut_{generic_transmit_byte, generic_receive_byte};
-
-    static std::string data_;
-    static Payload payloadified_negative_acknowledge_;
-    static Payload payloadified_acknowledge_;
-    static Payload payloadified_data_;
-    static std::map<uint8_t, uint8_t> lookup_map_;
 };
-
-Payload Fixture::received_{};
-
-std::string Fixture::data_{"abcd"};
-Payload Fixture::payloadified_negative_acknowledge_;
-Payload Fixture::payloadified_acknowledge_;
-Payload Fixture::payloadified_data_;
-
-std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, TransmitWithAcknowledgeWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_datalink_tx_nack.cpp
+++ b/test/unit/osi_layers/test_datalink_tx_nack.cpp
@@ -9,12 +9,9 @@
 #include "osi_layers/datalink.h"
 
 #include "utilities.h"
+#include "test_unit_base.h"
 
-constexpr uint8_t payload_size_byte_count{1};
-constexpr uint8_t data_negative_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::NegativeAcknowledge)};
-constexpr uint8_t data_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::Acknowledge)};
-
-class Fixture : public ::testing::Test
+class Fixture : public UnitBase
 {
 public:
     static void generic_transmit_byte(const uint8_t payload)
@@ -32,13 +29,7 @@ public:
 protected:
     virtual void SetUp() override
     {
-        received_.Reset();
-
-        payloadified_negative_acknowledge_ = append_crc_to_payload(Payload{data_negative_acknowledge_, 1});
-        payloadified_acknowledge_ = append_crc_to_payload(Payload{data_acknowledge_, 1});
-
-        payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
-        received_.size = 0;
+        UnitBase::SetUp();
 
         lookup_map_ = {
             {0, payload_size_byte_count + kCRCSize},
@@ -52,25 +43,9 @@ protected:
             {7, payloadified_negative_acknowledge_.data[2]},
         };
     }
-    virtual void TearDown() override {}
 
-    static Payload received_;
     UartHandshake<> sut_{generic_transmit_byte, generic_receive_byte};
-
-    static std::string data_;
-    static Payload payloadified_negative_acknowledge_;
-    static Payload payloadified_acknowledge_;
-    static Payload payloadified_data_;
-    static std::map<uint8_t, uint8_t> lookup_map_;
 };
-
-Payload Fixture::received_{};
-
-std::string Fixture::data_{"abcd"};
-Payload Fixture::payloadified_negative_acknowledge_;
-Payload Fixture::payloadified_acknowledge_;
-Payload Fixture::payloadified_data_;
-std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, TransmitWithAcknowledgeWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_datalink_tx_nack.cpp
+++ b/test/unit/osi_layers/test_datalink_tx_nack.cpp
@@ -11,6 +11,7 @@
 #include "utilities.h"
 
 constexpr uint8_t data_negative_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::NegativeAcknowledge)};
+constexpr uint8_t data_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::Acknowledge)};
 
 class Fixture : public ::testing::Test
 {
@@ -22,11 +23,22 @@ public:
 
     static uint8_t generic_receive_byte()
     {
-        if (received_.size == 3)
-        {
-            received_.size = 0;
-        }
-        return payloadified_negative_acknowledge_.data[received_.size++];
+        static uint8_t call_count = 0;
+        constexpr uint8_t payload_size_byte_count{1};
+
+        std::map<uint8_t, uint8_t> lookup_map{
+            {0, payload_size_byte_count + kCRCSize},
+            {1, payloadified_negative_acknowledge_.data[0]},
+            {2, payloadified_negative_acknowledge_.data[1]},
+            {3, payloadified_negative_acknowledge_.data[2]},
+
+            {4, payload_size_byte_count + kCRCSize},
+            {5, payloadified_negative_acknowledge_.data[0]},
+            {6, payloadified_negative_acknowledge_.data[1]},
+            {7, payloadified_negative_acknowledge_.data[2]},
+        };
+
+        return lookup_map[call_count++];
     }
 
 protected:
@@ -35,8 +47,10 @@ protected:
         received_.Reset();
 
         payloadified_negative_acknowledge_ = Payload{data_negative_acknowledge_, 1};
+        payloadified_acknowledge_ = Payload{data_acknowledge_, 1};
 
         payloadified_negative_acknowledge_ = append_crc_to_payload(payloadified_negative_acknowledge_);
+        payloadified_acknowledge_ = append_crc_to_payload(payloadified_acknowledge_);
 
         payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
         received_.size = 0;
@@ -48,6 +62,7 @@ protected:
 
     static std::string data_;
     static Payload payloadified_negative_acknowledge_;
+    static Payload payloadified_acknowledge_;
     static Payload payloadified_data_;
 };
 
@@ -55,9 +70,10 @@ Payload Fixture::received_{};
 
 std::string Fixture::data_{"abcd"};
 Payload Fixture::payloadified_negative_acknowledge_;
+Payload Fixture::payloadified_acknowledge_;
 Payload Fixture::payloadified_data_;
 
-TEST_F(Fixture, TransmitNegativeAcknowledgeWorks_WhenTypical)
+TEST_F(Fixture, TransmitWithAcknowledgeWorks_WhenTypical)
 {
     CommunicationStatus result = sut_.TransmitWithAcknowledge(payloadified_data_);
 

--- a/test/unit/osi_layers/test_datalink_tx_nack.cpp
+++ b/test/unit/osi_layers/test_datalink_tx_nack.cpp
@@ -23,7 +23,7 @@ public:
 
     static uint8_t generic_receive_byte()
     {
-        static uint8_t call_count = 0;
+        static uint8_t call_count{0};
         constexpr uint8_t payload_size_byte_count{1};
 
         std::map<uint8_t, uint8_t> lookup_map{

--- a/test/unit/osi_layers/test_datalink_tx_nack.cpp
+++ b/test/unit/osi_layers/test_datalink_tx_nack.cpp
@@ -10,6 +10,7 @@
 
 #include "utilities.h"
 
+constexpr uint8_t payload_size_byte_count{1};
 constexpr uint8_t data_negative_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::NegativeAcknowledge)};
 constexpr uint8_t data_acknowledge_[]{static_cast<uint8_t>(CommunicationStatus::Acknowledge)};
 
@@ -24,9 +25,22 @@ public:
     static uint8_t generic_receive_byte()
     {
         static uint8_t call_count{0};
-        constexpr uint8_t payload_size_byte_count{1};
 
-        std::map<uint8_t, uint8_t> lookup_map{
+        return lookup_map_[call_count++];
+    }
+
+protected:
+    virtual void SetUp() override
+    {
+        received_.Reset();
+
+        payloadified_negative_acknowledge_ = append_crc_to_payload(Payload{data_negative_acknowledge_, 1});
+        payloadified_acknowledge_ = append_crc_to_payload(Payload{data_acknowledge_, 1});
+
+        payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
+        received_.size = 0;
+
+        lookup_map_ = {
             {0, payload_size_byte_count + kCRCSize},
             {1, payloadified_negative_acknowledge_.data[0]},
             {2, payloadified_negative_acknowledge_.data[1]},
@@ -37,23 +51,6 @@ public:
             {6, payloadified_negative_acknowledge_.data[1]},
             {7, payloadified_negative_acknowledge_.data[2]},
         };
-
-        return lookup_map[call_count++];
-    }
-
-protected:
-    virtual void SetUp() override
-    {
-        received_.Reset();
-
-        payloadified_negative_acknowledge_ = Payload{data_negative_acknowledge_, 1};
-        payloadified_acknowledge_ = Payload{data_acknowledge_, 1};
-
-        payloadified_negative_acknowledge_ = append_crc_to_payload(payloadified_negative_acknowledge_);
-        payloadified_acknowledge_ = append_crc_to_payload(payloadified_acknowledge_);
-
-        payloadified_data_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
-        received_.size = 0;
     }
     virtual void TearDown() override {}
 
@@ -64,6 +61,7 @@ protected:
     static Payload payloadified_negative_acknowledge_;
     static Payload payloadified_acknowledge_;
     static Payload payloadified_data_;
+    static std::map<uint8_t, uint8_t> lookup_map_;
 };
 
 Payload Fixture::received_{};
@@ -72,6 +70,7 @@ std::string Fixture::data_{"abcd"};
 Payload Fixture::payloadified_negative_acknowledge_;
 Payload Fixture::payloadified_acknowledge_;
 Payload Fixture::payloadified_data_;
+std::map<uint8_t, uint8_t> Fixture::lookup_map_;
 
 TEST_F(Fixture, TransmitWithAcknowledgeWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_physical_receive_transmit.cpp
+++ b/test/unit/osi_layers/test_physical_receive_transmit.cpp
@@ -56,7 +56,7 @@ TEST_F(Fixture, ReceiveWorks_WhenTypical)
 {
   auto expected = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
 
-  received_ = sut_.Receive(static_cast<uint8_t>(data_.length()));
+  received_ = sut_.Receive();
 
   ASSERT_EQ(received_, expected);
 }
@@ -66,7 +66,7 @@ TEST_F(Fixture, ReceiveCRCError_WhenCRCMismatch)
   payloadified_.data[payloadified_.size - 1] = payloadified_.data[payloadified_.size - 1] + 42;
   auto expected = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
 
-  received_ = sut_.Receive(static_cast<uint8_t>(data_.length()));
+  received_ = sut_.Receive();
 
   ASSERT_FALSE(received_ == expected);
 }
@@ -76,7 +76,7 @@ TEST_F(Fixture, ReceiveError_WhenIncorrectPayloadLength)
   payloadified_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length() - 1)};
   auto expected = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
 
-  received_ = sut_.Receive(static_cast<uint8_t>(data_.length()));
+  received_ = sut_.Receive();
 
   ASSERT_FALSE(received_ == expected);
 }
@@ -85,7 +85,7 @@ TEST_F(Fixture, ReceiveError_WhenForgotCRCAppend)
 {
   auto expected = Payload{data_.c_str(), static_cast<uint8_t>(data_.length() + kCRCSize)};
 
-  sut_.Receive(static_cast<uint8_t>(data_.length() + kCRCSize));
+  sut_.Receive();
 
   ASSERT_FALSE(received_ == expected);
 }

--- a/test/unit/osi_layers/test_physical_receive_transmit.cpp
+++ b/test/unit/osi_layers/test_physical_receive_transmit.cpp
@@ -12,12 +12,29 @@ class Fixture : public ::testing::Test
 public:
   static void generic_transmit_byte(const uint8_t payload)
   {
-    transmitted_.data[transmitted_.size++] = payload;
+    if (!transmitted_.size)
+    {
+      transmitted_.size = payload;
+    }
+    else
+    {
+      transmitted_.data[pos_in_transmission_++] = payload;
+    }
   }
 
   static uint8_t generic_receive_byte()
   {
-    return payloadified_.data[received_.size++];
+    if (!pos_in_reception_)
+    {
+      pos_in_reception_++;
+      return payloadified_.size;
+    }
+    else
+    {
+      auto result = payloadified_.data[pos_in_reception_ - 1];
+      pos_in_reception_++;
+      return result;
+    }
   }
 
 protected:
@@ -27,6 +44,8 @@ protected:
     received_.Reset();
 
     payloadified_ = Payload{data_.c_str(), static_cast<uint8_t>(data_.length())};
+    pos_in_transmission_ = {};
+    pos_in_reception_ = {};
   }
   virtual void TearDown() override {}
 
@@ -35,6 +54,7 @@ protected:
 
   static std::string data_;
   static Payload payloadified_;
+  static uint8_t pos_in_transmission_, pos_in_reception_;
 };
 
 Payload Fixture::transmitted_{};
@@ -42,6 +62,7 @@ Payload Fixture::received_{};
 
 std::string Fixture::data_{"abcd"};
 Payload Fixture::payloadified_;
+uint8_t Fixture::pos_in_transmission_, Fixture::pos_in_reception_;
 
 TEST_F(Fixture, TransmitWorks_WhenTypical)
 {

--- a/test/unit/osi_layers/test_physical_sanity.cpp
+++ b/test/unit/osi_layers/test_physical_sanity.cpp
@@ -33,7 +33,7 @@ TEST_F(Fixture, ReceiveDefaultPayload_WhenExpectedCountGreaterThanMaxPayloadSize
 {
   auto expected = Payload{};
 
-  auto actual = sut_.Receive(kPayloadMaxSize + 1);
+  auto actual = sut_.Receive();
 
   ASSERT_EQ(actual, expected);
 }

--- a/test/unit/osi_layers/test_physical_sanity.cpp
+++ b/test/unit/osi_layers/test_physical_sanity.cpp
@@ -29,16 +29,16 @@ protected:
 
 uint8_t Fixture::data_;
 
-TEST_F(Fixture, ReceiveDefaultPayload_WhenExpectedCountGreaterThanMaxPayloadSize)
-{
-  auto expected = Payload{};
+// TEST_F(Fixture, ResetPayloadSizeWorks_WhenTypical)
+// {
+//   auto initial = Payload{"abc", 3};
 
-  auto actual = sut_.Receive();
+//   initial.Reset();
 
-  ASSERT_EQ(actual, expected);
-}
+//   ASSERT_EQ(initial.size, 0);
+// }
 
-TEST_F(Fixture, ResetPayloadWorks_WhenTypical)
+TEST_F(Fixture, ResetPayloadDataWorks_WhenTypical)
 {
   auto initial = Payload{"abc", 3};
   auto expected = Payload{};


### PR DESCRIPTION
In order to know how many bytes are sent during the communication, the length needs to be sent  first.

```bash
➜  protocolized_communication git:(d83a900) ✗ bazel test //...                                     
INFO: Analyzed 10 targets (20 packages loaded, 327 targets configured).
INFO: Found 2 targets and 8 test targets...
INFO: Elapsed time: 9.592s, Critical Path: 3.99s
INFO: 45 processes: 45 linux-sandbox.
INFO: Build completed successfully, 84 total actions
//:unit/osi_layers/test_datalink_rx_ack                                  PASSED in 0.1s
//:unit/osi_layers/test_datalink_rx_nack                                 PASSED in 0.1s
//:unit/osi_layers/test_datalink_tx_ack                                  PASSED in 0.1s
//:unit/osi_layers/test_datalink_tx_nack                                 PASSED in 0.1s
//:unit/osi_layers/test_physical_receive_transmit                        PASSED in 0.1s
//:unit/osi_layers/test_physical_sanity                                  PASSED in 0.1s
//:unit/test_crc                                                         PASSED in 0.1s
//:unit/test_payload                                                     PASSED in 0.1s

Executed 8 out of 8 tests: 8 tests pass.
INFO: Build completed successfully, 84 total actions
```