### PR TITLE
Use structured payload

### DIFF
--- a/include/payload.h
+++ b/include/payload.h
@@ -6,7 +6,14 @@
 struct Payload
 {
     uint8_t size{0};
-    uint8_t data[kPayloadMaxSize]{};
+    union {
+        uint8_t data[kPayloadMaxSize]{};
+        struct
+        {
+            uint8_t data[kPayloadMaxSize - kCRCSize]{};
+            uint8_t crc[kCRCSize];
+        } stuctured;
+    };
 
     Payload()
     {

--- a/src/crc.cpp
+++ b/src/crc.cpp
@@ -12,8 +12,9 @@ TCRCChecksum CRC::received_crc(const Payload &payload) const
     TCRCChecksum crc = 0;
     for (uint8_t i = 0; i < kCRCSize; ++i)
     {
-        uint8_t current_crc_byte = payload.data[payload.size - kCRCSize + i];
-        crc |= current_crc_byte << i * 8;
+        // uint8_t current_crc_byte = payload.data[payload.size - kCRCSize + i];
+        // crc |= current_crc_byte << i * 8;
+        crc |= payload.stuctured.crc[i] << i * 8;
     }
     return crc;
 }
@@ -47,7 +48,8 @@ Payload CRC::append_crc_to_payload(const Payload &payload) const
         for (uint8_t i = 0; i < kCRCSize; ++i)
         {
             uint8_t one_crc_byte = static_cast<uint8_t>(crc >> i * 8);
-            result.data[result.size++] = one_crc_byte;
+            result.stuctured.crc[i] = one_crc_byte;
+            // result.data[result.size++] = one_crc_byte;
         }
     }
     return result;

--- a/test/unit/test_crc.cpp
+++ b/test/unit/test_crc.cpp
@@ -54,8 +54,8 @@ TEST_F(Fixture, AppendCRCToPayloadWorks_WhenTypical)
 {
     TCRCChecksum computed_checksum = sut_.computed_crc(payloadified_, payloadified_.size);
     auto expected = payloadified_;
-    expected.data[expected.size++] = static_cast<uint8_t>(computed_checksum);
-    expected.data[expected.size++] = static_cast<uint8_t>(computed_checksum >> 8);
+    expected.stuctured.crc[0] = static_cast<uint8_t>(computed_checksum);
+    expected.stuctured.crc[1] = static_cast<uint8_t>(computed_checksum >> 8);
 
     payloadified_ = sut_.append_crc_to_payload(payloadified_);
 


### PR DESCRIPTION
This PR is taking a swing at https://github.com/mihaigalos/osi_stack/issues/14.
Specifically, CRC becomes structured here.

There is no easy way to make the position of CRC arbitrary (i.e.: known at runtime).
The implementation of the PR would mean the CRC is statically put at the end of the structured data.
