### PR TITLE
Revert "Migrate to gcc9 on Ubuntu Focal"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # yamllint disable-line rule:line-length
 
-dist: focal
+dist: bionic
 
 matrix:
   include:
@@ -10,7 +10,7 @@ matrix:
         sources:
           - ubuntu-toolchain-r-test
         packages:
-          - g++-9
+          - g++-7
           - lcov
           - pkg-config
           - "python3"


### PR DESCRIPTION
Reverts mihaigalos/osi_stack#34 because of broken `master`.
Upstream reason: https://github.com/bazelbuild/bazel/issues/9406.